### PR TITLE
Add Power Platform Provider for Terraform

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,7 +429,10 @@
 							href="https://docs.microsoft.com/powerapps/pricing-billing-skus">Licensing documentation</a>
 					</li>
 					<li>Microsoft's approach to deploying Power Apps for all employees - <a
-							href="https://aka.ms/ThrivePresentation">Pat Dunn’s presentation at Biz Apps Summit</a></li>
+							href="https://aka.ms/ThrivePresentation">Pat Dunn’s presentation at Biz Apps Summit</a>
+					</li>
+					<li>Power Platform Terraform Provider - <a
+						href="https://microsoft.github.io/terraform-provider-power-platform/">Power Platform Terraform Provider</a></li>
 				</ul>
 			</details>
 			<details>


### PR DESCRIPTION
This pull request includes a small change to the `index.html` file. The change adds a new list item with a link to the Power Platform Terraform Provider documentation.

Changes in `index.html`:

* Added a new list item with a link to the Power Platform Terraform Provider documentation.